### PR TITLE
fix(release-plz): avoid legacy v0.1.0 tag collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Releases are fully automated in GitHub Actions and follow a release-PR model:
 1. Every push to `main` runs `.github/workflows/release.yml`.
 2. `release-plz` keeps a release PR open with version/changelog updates (`CHANGELOG.md`).
 3. Merging that release PR triggers:
-   * Tag + GitHub release (`vX.Y.Z`)
+   * Tag + GitHub release (`tuitbot-cli-vX.Y.Z`)
    * Cross-platform binary builds (`linux`, `macOS Intel`, `macOS Apple Silicon`, `windows`)
    * Asset uploads + `SHA256SUMS` checksum file
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,6 @@
 [workspace]
 release = false
-git_only = true
+git_only = false
 publish = false
 release_always = false
 semver_check = false
@@ -9,7 +9,20 @@ git_tag_name = "v{{ version }}"
 git_release_name = "v{{ version }}"
 
 [[package]]
+name = "tuitbot-core"
+release = false
+git_only = false
+
+[[package]]
+name = "tuitbot-mcp"
+release = false
+git_only = false
+
+[[package]]
 name = "tuitbot-cli"
 release = true
+git_only = true
+git_tag_name = "tuitbot-cli-v{{ version }}"
+git_release_name = "tuitbot-cli-v{{ version }}"
 changelog_path = "CHANGELOG.md"
 changelog_include = ["tuitbot-core", "tuitbot-mcp"]


### PR DESCRIPTION
## Why release-plz keeps failing
`release-plz` was still reading legacy `v0.1.0` tag history (created before packaging fixes). That tag points to manifests where local path deps were not package-compatible, so `release-pr` failed while calculating next versions.

## What this changes
- scope `git_only` to `tuitbot-cli` only
- keep `tuitbot-core` and `tuitbot-mcp` explicitly non-releasing in release-plz config
- switch CLI tag/release template to package-specific tags:
  - `tuitbot-cli-v{{ version }}`
- update README release section to reflect the actual tag format

## Validation
- `release-plz update --config release-plz.toml --allow-dirty` now succeeds locally
