### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.1...tuitbot-cli-v0.1.2) - 2026-02-24
+
+### Added
+
+- Introduce analytics dashboard with components for performance, follower trends, and engagement metrics.
+- Implement API token authentication, WebSocket event broadcasting, and new API routes for settings, runtime control, and expanded approval management.
+- Introduce `tuitbot-server` crate to provide a read-only HTTP API for storage.
+
 ## [0.1.1](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.0...tuitbot-cli-v0.1.1) - 2026-02-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,7 +3288,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -15,8 +15,8 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.1", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.1", path = "../tuitbot-mcp" }
+tuitbot-core = { version = "0.1.2", path = "../tuitbot-core" }
+tuitbot-mcp = { version = "0.1.2", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.1", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.2", path = "../tuitbot-core" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,4 +23,4 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.1", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.2", path = "../tuitbot-core", features = ["test-helpers"] }

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-server"
 keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.1", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.2", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -27,7 +27,7 @@ rand = "0.8"
 hex = "0.4"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.1", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.2", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-core`: 0.1.1 -> 0.1.2
* `tuitbot-mcp`: 0.1.1 -> 0.1.2
* `tuitbot-cli`: 0.1.1 -> 0.1.2
* `tuitbot-server`: 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>



## `tuitbot-cli`

<blockquote>

## [0.1.2](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.1...tuitbot-cli-v0.1.2) - 2026-02-24

### Added

- Introduce analytics dashboard with components for performance, follower trends, and engagement metrics.
- Implement API token authentication, WebSocket event broadcasting, and new API routes for settings, runtime control, and expanded approval management.
- Introduce `tuitbot-server` crate to provide a read-only HTTP API for storage.
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).