### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.3...tuitbot-cli-v0.1.4) - 2026-02-24
+
+### Added
+
+- Add LLM cost tracking, pricing, and a dashboard for usage reporting.
+- Remove `auto_follow` and `follow_warmup_days` settings, streamlining target account management and reinforcing the co-pilot approach.
+- remove auto-follow and follow warmup features for target accounts
+- Add aarch64-unknown-linux-gnu support to release builds and the update command.
+- Add pricing support for Gemini and DeepSeek LLM models.
+- Implement a new strategy module for weekly performance reports, recommendations, and a dedicated dashboard page.
+
 ### Added
 
 - Add Strategy dashboard page with weekly growth scorecard, recommendation engine, and historical trend charts.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,7 +3288,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -15,8 +15,8 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.3", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.3", path = "../tuitbot-mcp" }
+tuitbot-core = { version = "0.1.4", path = "../tuitbot-core" }
+tuitbot-mcp = { version = "0.1.4", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.3", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.4", path = "../tuitbot-core" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,4 +23,4 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.3", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.4", path = "../tuitbot-core", features = ["test-helpers"] }

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-server"
 keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.3", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.4", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -27,7 +27,7 @@ rand = "0.8"
 hex = "0.4"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.3", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.4", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-core`: 0.1.3 -> 0.1.4
* `tuitbot-mcp`: 0.1.3 -> 0.1.4
* `tuitbot-cli`: 0.1.3 -> 0.1.4
* `tuitbot-server`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>



## `tuitbot-cli`

<blockquote>

## [0.1.4](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.3...tuitbot-cli-v0.1.4) - 2026-02-24

### Added

- Add LLM cost tracking, pricing, and a dashboard for usage reporting.
- Remove `auto_follow` and `follow_warmup_days` settings, streamlining target account management and reinforcing the co-pilot approach.
- remove auto-follow and follow warmup features for target accounts
- Add aarch64-unknown-linux-gnu support to release builds and the update command.
- Add pricing support for Gemini and DeepSeek LLM models.
- Implement a new strategy module for weekly performance reports, recommendations, and a dedicated dashboard page.

### Added

- Add Strategy dashboard page with weekly growth scorecard, recommendation engine, and historical trend charts.
- Add `strategy_reports` table and storage CRUD for persisted weekly reports.
- Add `strategy/metrics.rs` module with date-ranged queries over existing analytics tables.
- Add `strategy/recommendations.rs` with 8-rule deterministic recommendation engine.
- Add 4 new API endpoints: `GET /api/strategy/current`, `GET /api/strategy/history`, `POST /api/strategy/refresh`, `GET /api/strategy/inputs`.
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).