### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.6...tuitbot-cli-v0.1.7) - 2026-02-26
+
+### Added
+
+- expand X API integration with new methods for users, likes, and bookmarks, and update related scopes and tools.
+- introduce runtime profiles for MCP, decoupling kernel tools for API-only usage
+- improve self-update logic to find the latest compatible release for the current platform from recent GitHub releases.
+- Add comprehensive market domination roadmap content and implement a new scraper provider with mutation guard integration into workflow actions.
+- introduce comprehensive evaluation harness, conformance tests, and benchmarking tools, while restructuring roadmap artifacts
+- Implement golden fixture and conformance tests for tool response schema drift detection, adding session 09 evaluation tools and artifacts, and updating CI.
+- Implement retry logic for social provider calls, introduce idempotency tools, and add new testing utilities.
+- Implement provider-level retry, idempotency, refined error handling, and normalized pagination for improved reliability.
+
+### Other
+
+- Merge branch 'main' into feat/mcp_improvements_new
+- Update performance benchmarks, evaluation results, and report timestamps, and refine test mock comments.
+- introduce `ErrorCode` enum for standardized error handling and update tool contract definitions and metadata.
+- introduce contract, provider, and kernel modules to decouple MCP logic and update related tools and roadmap artifacts.
+
 ## [0.1.6](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.5...tuitbot-cli-v0.1.6) - 2026-02-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,7 +3145,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -15,8 +15,8 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.6", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.6", path = "../tuitbot-mcp" }
+tuitbot-core = { version = "0.1.7", path = "../tuitbot-core" }
+tuitbot-mcp = { version = "0.1.7", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.6", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.7", path = "../tuitbot-core" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,4 +23,4 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.6", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.7", path = "../tuitbot-core", features = ["test-helpers"] }

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-server"
 keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.6", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.7", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -28,7 +28,7 @@ hex = "0.4"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.6", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.7", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-core`: 0.1.6 -> 0.1.7
* `tuitbot-mcp`: 0.1.6 -> 0.1.7
* `tuitbot-cli`: 0.1.6 -> 0.1.7
* `tuitbot-server`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>



## `tuitbot-cli`

<blockquote>

## [0.1.7](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.6...tuitbot-cli-v0.1.7) - 2026-02-26

### Added

- expand X API integration with new methods for users, likes, and bookmarks, and update related scopes and tools.
- introduce runtime profiles for MCP, decoupling kernel tools for API-only usage
- improve self-update logic to find the latest compatible release for the current platform from recent GitHub releases.
- Add comprehensive market domination roadmap content and implement a new scraper provider with mutation guard integration into workflow actions.
- introduce comprehensive evaluation harness, conformance tests, and benchmarking tools, while restructuring roadmap artifacts
- Implement golden fixture and conformance tests for tool response schema drift detection, adding session 09 evaluation tools and artifacts, and updating CI.
- Implement retry logic for social provider calls, introduce idempotency tools, and add new testing utilities.
- Implement provider-level retry, idempotency, refined error handling, and normalized pagination for improved reliability.

### Other

- Merge branch 'main' into feat/mcp_improvements_new
- Update performance benchmarks, evaluation results, and report timestamps, and refine test mock comments.
- introduce `ErrorCode` enum for standardized error handling and update tool contract definitions and metadata.
- introduce contract, provider, and kernel modules to decouple MCP logic and update related tools and roadmap artifacts.
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).