### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.7...tuitbot-cli-v0.1.8) - 2026-02-26
+
+### Added
+
+- Introduce `mcp manifest` command and refactor the MCP server API to include a read-only variant.
+- Introduce and implement `full`, `readonly`, and `api-readonly` MCP profiles with updated routing and tool curation.
+- add comprehensive boundary tests to enforce tool profile safety, mutation restrictions, and read-only integrity, updating artifact reports.
+- Add scripts for generating and checking MCP manifests, update documentation, and refresh evaluation artifacts.
+
+### Other
+
+- update mcp-reference docs tool count back to 64 tools and add update features
+
 ### Added
 
 - Three MCP profiles: `--profile full` (64 tools, default), `--profile readonly` (10 tools), `--profile api-readonly` (20 tools). Read-only profiles are safe by construction — mutation tools are not registered, not policy-blocked.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,7 +3145,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 tuitbot-core = { version = "0.1.7", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.7", path = "../tuitbot-mcp" }
+tuitbot-mcp = { version = "0.1.8", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-mcp`: 0.1.7 -> 0.1.8
* `tuitbot-cli`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>


## `tuitbot-cli`

<blockquote>

## [0.1.8](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.7...tuitbot-cli-v0.1.8) - 2026-02-26

### Added

- Introduce `mcp manifest` command and refactor the MCP server API to include a read-only variant.
- Introduce and implement `full`, `readonly`, and `api-readonly` MCP profiles with updated routing and tool curation.
- add comprehensive boundary tests to enforce tool profile safety, mutation restrictions, and read-only integrity, updating artifact reports.
- Add scripts for generating and checking MCP manifests, update documentation, and refresh evaluation artifacts.

### Other

- update mcp-reference docs tool count back to 64 tools and add update features

### Added

- Three MCP profiles: `--profile full` (64 tools, default), `--profile readonly` (10 tools), `--profile api-readonly` (20 tools). Read-only profiles are safe by construction — mutation tools are not registered, not policy-blocked.
- `mcp manifest` command for machine-readable profile introspection.
- Auto-generated tool manifests in `docs/generated/` validated by CI.
- MCP profile operator runbook for verifying profiles and read-only safety.
- MCP profiles release checklist with completed tasks, known limitations, and rollback strategy.

### Changed

- MCP documentation updated to reflect profile-based model (replaces legacy lane/api terminology).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).