### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.9...tuitbot-cli-v0.1.10) - 2026-02-27
+
+### Added
+
+- Session 5 — route autopilot adapters through toolkit layer
+- Session 3 — expose flat MCP utility profiles
+- Session 7 — refresh manifests docs and e2e tests
+- Session 6 — extract workflow composers to core, rewire MCP handlers
+- Session 4 — implement unified mutation policy gateway
+- Session 2 — stateless Toolkit layer and MCP x_actions refactor
+
 ## [0.1.9](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.8...tuitbot-cli-v0.1.9) - 2026-02-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,7 +3145,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -15,8 +15,8 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.8", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.9", path = "../tuitbot-mcp" }
+tuitbot-core = { version = "0.1.9", path = "../tuitbot-core" }
+tuitbot-mcp = { version = "0.1.10", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.8", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.9", path = "../tuitbot-core" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,4 +23,4 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.8", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.9", path = "../tuitbot-core", features = ["test-helpers"] }

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-server"
 keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.8", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.9", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -28,7 +28,7 @@ hex = "0.4"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.8", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.9", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-core`: 0.1.8 -> 0.1.9
* `tuitbot-mcp`: 0.1.9 -> 0.1.10
* `tuitbot-cli`: 0.1.9 -> 0.1.10
* `tuitbot-server`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>



## `tuitbot-cli`

<blockquote>

## [0.1.10](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.9...tuitbot-cli-v0.1.10) - 2026-02-27

### Added

- Session 5 — route autopilot adapters through toolkit layer
- Session 3 — expose flat MCP utility profiles
- Session 7 — refresh manifests docs and e2e tests
- Session 6 — extract workflow composers to core, rewire MCP handlers
- Session 4 — implement unified mutation policy gateway
- Session 2 — stateless Toolkit layer and MCP x_actions refactor
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).