### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.10...tuitbot-cli-v0.1.11) - 2026-02-27
+
+### Added
+
+- Session 3 — DM API tool coverage
+- Session 5 — enterprise admin/compliance API tool coverage (7 tools)
+- Session 2 — enterprise security foundation for universal requests
+- Introduce profile completeness tracking, refactor config modules with new types and validation, and add enterprise API parity documentation.
+- Session 6 — manifest runtime parity and conformance
+- Session 4 — Ads/Campaign API tool coverage (16 tools)
+
+### Other
+
+- Reorganize `x_api` client, update config types, and introduce new evaluation and roadmap artifacts."
+
 ### Added
 
 - **X Enterprise API Parity** — 31 new typed MCP tools across 4 endpoint families:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,7 +3145,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -15,8 +15,8 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.9", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.10", path = "../tuitbot-mcp" }
+tuitbot-core = { version = "0.1.10", path = "../tuitbot-core" }
+tuitbot-mcp = { version = "0.1.11", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.9", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.10", path = "../tuitbot-core" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,4 +23,4 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.9", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.10", path = "../tuitbot-core", features = ["test-helpers"] }

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-server"
 keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.9", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.10", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -28,7 +28,7 @@ hex = "0.4"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.9", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.10", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-core`: 0.1.9 -> 0.1.10
* `tuitbot-mcp`: 0.1.10 -> 0.1.11
* `tuitbot-cli`: 0.1.10 -> 0.1.11
* `tuitbot-server`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>



## `tuitbot-cli`

<blockquote>

## [0.1.11](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.10...tuitbot-cli-v0.1.11) - 2026-02-27

### Added

- Session 3 — DM API tool coverage
- Session 5 — enterprise admin/compliance API tool coverage (7 tools)
- Session 2 — enterprise security foundation for universal requests
- Introduce profile completeness tracking, refactor config modules with new types and validation, and add enterprise API parity documentation.
- Session 6 — manifest runtime parity and conformance
- Session 4 — Ads/Campaign API tool coverage (16 tools)

### Other

- Reorganize `x_api` client, update config types, and introduce new evaluation and roadmap artifacts."

### Added

- **X Enterprise API Parity** — 31 new typed MCP tools across 4 endpoint families:
  - **Direct Messages** (8 tools): conversation listing, event retrieval, message sending, group DM creation. Available from API-readonly (reads) and Write (mutations) profiles. Requires `dm.read`/`dm.write` OAuth scopes.
  - **Ads / Campaign** (16 tools): account, campaign, line item, promoted tweet, targeting, analytics, and funding instrument management. Admin profile only. Routes to `ads-api.x.com`. Requires Ads API developer access.
  - **Compliance** (4 tools): compliance job listing, creation, and tweet usage statistics. Admin profile only. Requires `compliance.write` scope and elevated API tier.
  - **Stream Rules** (3 tools): filtered stream rule listing, creation, and deletion. Admin profile only. Requires `tweet.read` scope.
- Extended host allowlist with `ads-api.x.com` for Ads API routing, with all existing safety controls (SSRF protection, path validation, header blocklist).
- 3 new `ToolCategory` variants: `DirectMessage`, `Ads`, `Compliance`.
- 59 conformance tests: 7 parity, 15 DM, 18 Ads, 19 enterprise admin.
- Profile tool counts updated: Readonly 14, ApiReadonly 45 (+5), Write 112 (+8), Admin 139 (+31).

### Changed

- Documentation aligned with delivered enterprise API coverage: removed outdated claims that DM/Ads/Compliance APIs were unsupported, added enterprise tool reference sections, configuration guidance for enterprise API access, and updated all tool counts.
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).