### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.13...tuitbot-cli-v0.1.14) - 2026-02-28
+
+### Added
+
+- Session 8 — deployment mode source capabilities
+- Session 7 — cross source validation and release
+- Session 6 — google drive source adapter
+- Session 5 — source picker and local vault ux
+- Session 4 — winning dna retrieval
+- Session 3 — watchtower runtime and loop back
+- Session 2 — schema and ingest api
+
+### Other
+
+- introduce `relative_path_string` helper to standardize path string conversion across platforms.
+- reformat debouncer match statement for consistency
+- update debouncer cache type from `FileIdMap` to `RecommendedCache`
+
 ## [0.1.13](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.12...tuitbot-cli-v0.1.13) - 2026-02-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,7 +3324,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -15,8 +15,8 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.12", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.13", path = "../tuitbot-mcp" }
+tuitbot-core = { version = "0.1.13", path = "../tuitbot-core" }
+tuitbot-mcp = { version = "0.1.14", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.12", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.13", path = "../tuitbot-core" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,4 +23,4 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.12", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.13", path = "../tuitbot-core", features = ["test-helpers"] }

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-server"
 keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.12", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.13", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -29,7 +29,7 @@ sha2 = "0.10"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.12", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.13", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-core`: 0.1.12 -> 0.1.13
* `tuitbot-cli`: 0.1.13 -> 0.1.14
* `tuitbot-server`: 0.1.12 -> 0.1.13
* `tuitbot-mcp`: 0.1.13 -> 0.1.14

<details><summary><i><b>Changelog</b></i></summary><p>


## `tuitbot-cli`

<blockquote>

## [0.1.14](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.13...tuitbot-cli-v0.1.14) - 2026-02-28

### Added

- Session 8 — deployment mode source capabilities
- Session 7 — cross source validation and release
- Session 6 — google drive source adapter
- Session 5 — source picker and local vault ux
- Session 4 — winning dna retrieval
- Session 3 — watchtower runtime and loop back
- Session 2 — schema and ingest api

### Other

- introduce `relative_path_string` helper to standardize path string conversion across platforms.
- reformat debouncer match statement for consistency
- update debouncer cache type from `FileIdMap` to `RecommendedCache`
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).