### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.14...tuitbot-cli-v0.1.15) - 2026-02-28
+
+### Other
+
+- modularize the `update` command into separate files for improved organization and maintainability.
+
 ## [0.1.14](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.13...tuitbot-cli-v0.1.14) - 2026-02-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,7 +3359,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3444,7 +3444,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-cli`: 0.1.14 -> 0.1.15
* `tuitbot-server`: 0.1.13 -> 0.1.14

<details><summary><i><b>Changelog</b></i></summary><p>

## `tuitbot-cli`

<blockquote>

## [0.1.15](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.14...tuitbot-cli-v0.1.15) - 2026-02-28

### Other

- modularize the `update` command into separate files for improved organization and maintainability.
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).