### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.19...tuitbot-cli-v0.1.20) - 2026-03-04
+
+### Added
+
+- Session 3 — runtime scraper backend
+- Update AI action keyboard shortcut to Cmd+Shift+J and refresh generated documentation and roadmap artifacts.
+- Session 2 — settings x access mode
+
 ## [0.1.19](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.18...tuitbot-cli-v0.1.19) - 2026-03-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3432,7 +3432,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3518,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -15,8 +15,8 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.17", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.18", path = "../tuitbot-mcp" }
+tuitbot-core = { version = "0.1.18", path = "../tuitbot-core" }
+tuitbot-mcp = { version = "0.1.19", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.17", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.18", path = "../tuitbot-core" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,4 +23,4 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.17", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.18", path = "../tuitbot-core", features = ["test-helpers"] }

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"
@@ -12,7 +12,7 @@ keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 include = ["src/**/*", "build.rs", "Cargo.toml", "dashboard-dist/**/*"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.17", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.18", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -34,7 +34,7 @@ rust-embed = { version = "8", features = ["mime-guess"] }
 mime_guess = "2"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.17", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.18", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-core`: 0.1.17 -> 0.1.18
* `tuitbot-cli`: 0.1.19 -> 0.1.20
* `tuitbot-server`: 0.1.17 -> 0.1.18
* `tuitbot-mcp`: 0.1.18 -> 0.1.19

<details><summary><i><b>Changelog</b></i></summary><p>


## `tuitbot-cli`

<blockquote>

## [0.1.20](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.19...tuitbot-cli-v0.1.20) - 2026-03-04

### Added

- Session 3 — runtime scraper backend
- Update AI action keyboard shortcut to Cmd+Shift+J and refresh generated documentation and roadmap artifacts.
- Session 2 — settings x access mode
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).