### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.20...tuitbot-cli-v0.1.21) - 2026-03-05
+
+### Added
+
+- Add account profile fields to the database schema, X API types, and integrate them across core, server, and dashboard components.
+- Session 2 — extend core generator contract
+
+### Other
+
+- Composer UI improvements.
+- update media preview URL handling in TweetEditor and regenerate roadmap artifacts.
+- Merge branch 'main' into feat/composer-rag
+
 ## [0.1.20](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.19...tuitbot-cli-v0.1.20) - 2026-03-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3432,7 +3432,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3518,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -15,8 +15,8 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.18", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.19", path = "../tuitbot-mcp" }
+tuitbot-core = { version = "0.1.19", path = "../tuitbot-core" }
+tuitbot-mcp = { version = "0.1.20", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.18", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.19", path = "../tuitbot-core" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,4 +23,4 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.18", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.19", path = "../tuitbot-core", features = ["test-helpers"] }

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"
@@ -12,7 +12,7 @@ keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 include = ["src/**/*", "build.rs", "Cargo.toml", "dashboard-dist/**/*"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.18", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.19", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -34,7 +34,7 @@ rust-embed = { version = "8", features = ["mime-guess"] }
 mime_guess = "2"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.18", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.19", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-core`: 0.1.18 -> 0.1.19
* `tuitbot-mcp`: 0.1.19 -> 0.1.20
* `tuitbot-cli`: 0.1.20 -> 0.1.21
* `tuitbot-server`: 0.1.18 -> 0.1.19

<details><summary><i><b>Changelog</b></i></summary><p>



## `tuitbot-cli`

<blockquote>

## [0.1.21](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.20...tuitbot-cli-v0.1.21) - 2026-03-05

### Added

- Add account profile fields to the database schema, X API types, and integrate them across core, server, and dashboard components.
- Session 2 — extend core generator contract

### Other

- Composer UI improvements.
- update media preview URL handling in TweetEditor and regenerate roadmap artifacts.
- Merge branch 'main' into feat/composer-rag
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).