### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -15,8 +15,8 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.21", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.22", path = "../tuitbot-mcp" }
+tuitbot-core = { version = "0.1.22", path = "../tuitbot-core" }
+tuitbot-mcp = { version = "0.1.23", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.21", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.22", path = "../tuitbot-core" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,4 +23,4 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.21", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.22", path = "../tuitbot-core", features = ["test-helpers"] }

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 include = ["src/**/*", "build.rs", "Cargo.toml", "dashboard-dist/**/*"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.21", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.22", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -34,7 +34,7 @@ rust-embed = { version = "8", features = ["mime-guess"] }
 mime_guess = "2"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.21", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.22", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-core`: 0.1.21 -> 0.1.22
* `tuitbot-cli`: 0.1.21 -> 0.1.22
* `tuitbot-server`: 0.1.19 -> 0.1.20
* `tuitbot-mcp`: 0.1.22 -> 0.1.23

<details><summary><i><b>Changelog</b></i></summary><p>


## `tuitbot-cli`

<blockquote>

## [0.1.22](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.21...tuitbot-cli-v0.1.22) - 2026-03-07

### Added

- Introduce `x-client-transaction` crate for handling X migration, token generation, and client transaction logic.
- Dynamically resolve X API CreateTweet GraphQL query ID and migrate local mode cookie transport to `rquest`, updating evaluation reports.
- Implement browser session management for local X API mode, including API endpoints and dashboard UI.
- Refactor analytics storage, introduce CLI upgrade command, and update dashboard API client and evaluation artifacts.
- Enhance local mode cookie transport by integrating `x-client-transaction` and updating generated reports.
- Session 2 — effective config and settings
- Refine content composition and publishing flow with explicit capability checks and updated approval mode logic.

### Fixed

- OAuth flow opens isolated webview and new accounts start with blank persona

### Other

- Remove empty state UI from accounts section and enable cookie transport for `get_me` in local mode.
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).