### PR TITLE
fix: OAuth CSRF state validation and config-aware backup/restore

### DIFF
--- a/crates/tuitbot-cli/src/commands/auth.rs
+++ b/crates/tuitbot-cli/src/commands/auth.rs
@@ -8,8 +8,9 @@
 use std::io::Write;
 use tuitbot_core::config::Config;
 use tuitbot_core::startup::{
-    build_auth_url, build_redirect_uri, exchange_auth_code, extract_auth_code, generate_pkce,
-    save_tokens_to_file, token_file_path, verify_credentials,
+    build_auth_url, build_redirect_uri, exchange_auth_code, extract_auth_code,
+    extract_callback_state, generate_pkce, save_tokens_to_file, token_file_path,
+    verify_credentials,
 };
 
 /// Execute the `tuitbot auth` command.
@@ -44,17 +45,24 @@ pub async fn execute(config: &Config, mode_override: Option<&str>) -> anyhow::Re
         "local_callback" => {
             if is_headless_environment() {
                 eprintln!("Headless environment detected — using manual authentication.\n");
-                run_manual_mode(&auth_url)?
+                run_manual_mode(&auth_url, &pkce.state)?
             } else {
                 run_callback_mode(
                     &auth_url,
                     &config.auth.callback_host,
                     config.auth.callback_port,
+                    &pkce.state,
                 )
                 .await?
             }
         }
-        _ => run_manual_mode(&auth_url)?,
+        "manual" => run_manual_mode(&auth_url, &pkce.state)?,
+        other => {
+            anyhow::bail!(
+                "Invalid auth mode: '{other}'. Must be 'manual' or 'local_callback'.\n\
+                 Fix [auth].mode in your config file or use --mode manual|local_callback."
+            );
+        }
     };
 
     // 5. Exchange the authorization code for tokens.
@@ -89,7 +97,7 @@ pub async fn execute(config: &Config, mode_override: Option<&str>) -> anyhow::Re
 /// Designed as the primary headless-friendly auth flow. Works from any
 /// terminal — local, SSH, VPS, or OpenClaw. The user opens the URL on
 /// any device with a browser, authorizes, then copies the code back.
-fn run_manual_mode(auth_url: &str) -> anyhow::Result<String> {
+fn run_manual_mode(auth_url: &str, expected_state: &str) -> anyhow::Result<String> {
     let token_path = token_file_path();
 
     eprintln!("=== X API Authentication ===\n");
@@ -112,7 +120,14 @@ fn run_manual_mode(auth_url: &str) -> anyhow::Result<String> {
         .read_line(&mut input)
         .map_err(|e| anyhow::anyhow!("failed to read input: {e}"))?;
 
-    let code = extract_auth_code(&input);
+    let trimmed = input.trim();
+
+    // If the input looks like a URL, validate the state parameter.
+    if trimmed.contains("code=") || trimmed.contains("state=") {
+        validate_callback_state(trimmed, expected_state)?;
+    }
+
+    let code = extract_auth_code(trimmed);
     if code.is_empty() {
         anyhow::bail!("No authorization code provided.");
     }
@@ -120,8 +135,32 @@ fn run_manual_mode(auth_url: &str) -> anyhow::Result<String> {
     Ok(code)
 }
 
+/// Validate the `state` parameter from a callback URL against the expected value.
+fn validate_callback_state(input: &str, expected_state: &str) -> anyhow::Result<()> {
+    let returned_state = extract_callback_state(input);
+    if returned_state.is_empty() {
+        anyhow::bail!(
+            "Callback URL is missing the 'state' parameter.\n\
+             Make sure you copied the entire URL from the address bar."
+        );
+    }
+    if returned_state != expected_state {
+        anyhow::bail!(
+            "OAuth state mismatch — the callback state does not match this auth session.\n\
+             This can happen if the URL is from a different or expired auth attempt.\n\
+             Please restart the auth flow and use the new URL."
+        );
+    }
+    Ok(())
+}
+
 /// Callback mode: start a local HTTP server, open the browser, and wait.
-async fn run_callback_mode(auth_url: &str, host: &str, port: u16) -> anyhow::Result<String> {
+async fn run_callback_mode(
+    auth_url: &str,
+    host: &str,
+    port: u16,
+    expected_state: &str,
+) -> anyhow::Result<String> {
     let addr = format!("{host}:{port}");
     let listener = tokio::net::TcpListener::bind(&addr).await.map_err(|e| {
         anyhow::anyhow!(
@@ -142,13 +181,13 @@ async fn run_callback_mode(auth_url: &str, host: &str, port: u16) -> anyhow::Res
              Falling back to manual authentication.\n"
         );
         drop(listener);
-        return run_manual_mode(auth_url);
+        return run_manual_mode(auth_url, expected_state);
     }
 
     // Wait for the callback with a 120-second timeout.
     let code = tokio::time::timeout(
         std::time::Duration::from_secs(120),
-        wait_for_callback(&listener),
+        wait_for_callback(&listener, expected_state),
     )
     .await
     .map_err(|_| {
@@ -162,7 +201,10 @@ async fn run_callback_mode(auth_url: &str, host: &str, port: u16) -> anyhow::Res
 }
 
 /// Wait for a single HTTP callback request and extract the authorization code.
-async fn wait_for_callback(listener: &tokio::net::TcpListener) -> anyhow::Result<String> {
+async fn wait_for_callback(
+    listener: &tokio::net::TcpListener,
+    expected_state: &str,
+) -> anyhow::Result<String> {
     let (mut stream, _addr) = listener.accept().await?;
 
     // Read the HTTP request.
@@ -176,7 +218,6 @@ async fn wait_for_callback(listener: &tokio::net::TcpListener) -> anyhow::Result
 
     // Check for access_denied error.
     if path.contains("error=access_denied") {
-        // Send error response.
         let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
             <html><body><h2>Authorization Denied</h2>\
             <p>You denied the authorization request. You can close this tab.</p>\
@@ -187,10 +228,26 @@ async fn wait_for_callback(listener: &tokio::net::TcpListener) -> anyhow::Result
         anyhow::bail!("Authorization denied by user.");
     }
 
+    // Validate the state parameter (CSRF protection).
+    let returned_state = extract_callback_state(path);
+    if returned_state.is_empty() || returned_state != expected_state {
+        let response = "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n\
+            <html><body><h2>Error</h2>\
+            <p>OAuth state mismatch. This may be a stale or forged callback. \
+            Please restart the auth flow.</p>\
+            </body></html>";
+        tokio::io::AsyncWriteExt::write_all(&mut stream, response.as_bytes())
+            .await
+            .ok();
+        anyhow::bail!(
+            "OAuth state mismatch in callback — the returned state does not match \
+             this auth session. Please restart the auth flow."
+        );
+    }
+
     // Extract the code parameter.
     let code = extract_auth_code(path);
     if code.is_empty() {
-        // Send error response.
         let response = "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n\
             <html><body><h2>Error</h2>\
             <p>No authorization code found in the callback.</p>\

--- a/crates/tuitbot-cli/src/commands/backup.rs
+++ b/crates/tuitbot-cli/src/commands/backup.rs
@@ -2,16 +2,19 @@
 
 use std::path::PathBuf;
 
-use tuitbot_core::startup::data_dir;
+use tuitbot_core::startup::{data_dir, resolve_db_path};
 use tuitbot_core::storage;
 
 use super::BackupArgs;
 use crate::output::CliOutput;
 
 /// Execute the `tuitbot backup` command.
-pub async fn execute(args: BackupArgs, out: CliOutput) -> anyhow::Result<()> {
-    let data = data_dir();
-    let db_path = data.join("tuitbot.db");
+pub async fn execute(args: BackupArgs, config_path: &str, out: CliOutput) -> anyhow::Result<()> {
+    let db_path = resolve_db_path(config_path);
+    let data = db_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(data_dir);
 
     if args.list {
         return list_backups(&data, out);

--- a/crates/tuitbot-cli/src/commands/restore.rs
+++ b/crates/tuitbot-cli/src/commands/restore.rs
@@ -3,14 +3,14 @@
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
-use tuitbot_core::startup::data_dir;
+use tuitbot_core::startup::resolve_db_path;
 use tuitbot_core::storage;
 
 use super::RestoreArgs;
 use crate::output::CliOutput;
 
 /// Execute the `tuitbot restore` command.
-pub async fn execute(args: RestoreArgs, out: CliOutput) -> anyhow::Result<()> {
+pub async fn execute(args: RestoreArgs, config_path: &str, out: CliOutput) -> anyhow::Result<()> {
     let backup_path = PathBuf::from(&args.backup_path);
 
     if !backup_path.exists() {
@@ -45,7 +45,7 @@ pub async fn execute(args: RestoreArgs, out: CliOutput) -> anyhow::Result<()> {
     }
 
     // Confirm unless --force.
-    let target = data_dir().join("tuitbot.db");
+    let target = resolve_db_path(config_path);
     if !args.force && std::io::stdin().is_terminal() {
         eprintln!("\nThis will replace the database at {}", target.display());
         eprintln!("A safety backup of the current database will be created first.");

--- a/crates/tuitbot-cli/src/main.rs
+++ b/crates/tuitbot-cli/src/main.rs
@@ -178,10 +178,10 @@ async fn run() -> anyhow::Result<()> {
         return commands::settings::execute(args, &cli.config, output_format).await;
     }
     if let Commands::Backup(args) = cli.command {
-        return commands::backup::execute(args, out).await;
+        return commands::backup::execute(args, &cli.config, out).await;
     }
     if let Commands::Restore(args) = cli.command {
-        return commands::restore::execute(args, out).await;
+        return commands::restore::execute(args, &cli.config, out).await;
     }
     if let Commands::Uninstall(args) = cli.command {
         return commands::uninstall::execute(args.force, args.data_only, out);

--- a/crates/tuitbot-core/src/startup.rs
+++ b/crates/tuitbot-core/src/startup.rs
@@ -468,6 +468,24 @@ pub fn extract_auth_code(input: &str) -> String {
     trimmed.to_string()
 }
 
+/// Extract the `state` parameter from a callback URL or query string.
+///
+/// Returns an empty string if no `state` parameter is found.
+pub fn extract_callback_state(input: &str) -> String {
+    let query = if let Some(q) = input.split('?').nth(1) {
+        // Strip HTTP version suffix if present (e.g. " HTTP/1.1").
+        q.split_whitespace().next().unwrap_or(q)
+    } else {
+        input.trim()
+    };
+    for pair in query.split('&') {
+        if let Some(value) = pair.strip_prefix("state=") {
+            return value.to_string();
+        }
+    }
+    String::new()
+}
+
 // ============================================================================
 // Startup Banner
 // ============================================================================
@@ -509,6 +527,18 @@ pub fn expand_tilde(path: &str) -> PathBuf {
         }
     }
     PathBuf::from(path)
+}
+
+/// Resolve the database path by loading the config file and reading `storage.db_path`.
+///
+/// Falls back to `~/.tuitbot/tuitbot.db` if the config cannot be loaded.
+pub fn resolve_db_path(config_path: &str) -> PathBuf {
+    use crate::config::Config;
+    if let Ok(config) = Config::load(Some(config_path)) {
+        expand_tilde(&config.storage.db_path)
+    } else {
+        data_dir().join("tuitbot.db")
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- **OAuth CSRF protection** — Validates the `state` parameter on OAuth callbacks in both `local_callback` and `manual` auth modes. Prevents an attacker from tricking a user into authorizing a forged callback URL.
- **Config-aware backup/restore** — `backup` and `restore` now read `storage.db_path` from the config file via `resolve_db_path()` instead of hardcoding `~/.tuitbot/tuitbot.db`. Fixes incorrect behavior when users configure a custom DB location.
- **Auth mode validation** — Rejects invalid `[auth].mode` values with a clear error message instead of silently falling through to manual mode.

## Changes

| File | What changed |
|------|-------------|
| `commands/auth.rs` | Validate `state` param in both callback and manual modes; reject invalid auth modes |
| `startup.rs` | Add `extract_callback_state()` and `resolve_db_path()` helpers |
| `commands/backup.rs` | Use `resolve_db_path()` instead of `data_dir().join("tuitbot.db")` |
| `commands/restore.rs` | Use `resolve_db_path()` instead of `data_dir().join("tuitbot.db")` |
| `main.rs` | Pass `&cli.config` to backup/restore execute functions |

## Test plan

- [x] `cargo fmt --all --check` — passes
- [x] `cargo clippy --workspace -- -D warnings` — passes
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace` — all tests pass
- [ ] Manual: `tuitbot auth` callback validates state parameter
- [ ] Manual: `tuitbot backup` uses correct DB path from config
- [ ] Manual: `tuitbot restore <path>` restores to config-specified DB path

🤖 Generated with [Claude Code](https://claude.com/claude-code)