### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.27...tuitbot-cli-v0.1.28) - 2026-03-09
+
+### Added
+
+- Session 5 — progressive activation and capability gating
+- Session 3 — profile analysis pipeline with two-pass inference
+- Session 2 — unified entry and X auth bootstrap
+
+### Fixed
+
+- scraper discovery false success and MCP readonly token requirement
+- resolve 12 QA issues — validation hardening, CLI flag conflicts, scraper mode, MCP mutations
+
 ## [0.1.27](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.26...tuitbot-cli-v0.1.27) - 2026-03-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,7 +4105,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -15,8 +15,8 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.26", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.27", path = "../tuitbot-mcp" }
+tuitbot-core = { version = "0.1.27", path = "../tuitbot-core" }
+tuitbot-mcp = { version = "0.1.28", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.26", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.27", path = "../tuitbot-core" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,4 +23,4 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.26", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.27", path = "../tuitbot-core", features = ["test-helpers"] }

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.25"
+version = "0.1.26"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"
@@ -12,7 +12,7 @@ keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 include = ["src/**/*", "build.rs", "Cargo.toml", "dashboard-dist/**/*"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.26", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.27", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -34,7 +34,7 @@ rust-embed = { version = "8", features = ["mime-guess"] }
 mime_guess = "2"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.26", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.27", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-core`: 0.1.26 -> 0.1.27
* `tuitbot-mcp`: 0.1.27 -> 0.1.28
* `tuitbot-cli`: 0.1.27 -> 0.1.28
* `tuitbot-server`: 0.1.25 -> 0.1.26

<details><summary><i><b>Changelog</b></i></summary><p>



## `tuitbot-cli`

<blockquote>

## [0.1.28](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.27...tuitbot-cli-v0.1.28) - 2026-03-09

### Added

- Session 5 — progressive activation and capability gating
- Session 3 — profile analysis pipeline with two-pass inference
- Session 2 — unified entry and X auth bootstrap

### Fixed

- scraper discovery false success and MCP readonly token requirement
- resolve 12 QA issues — validation hardening, CLI flag conflicts, scraper mode, MCP mutations
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).