### PR TITLE
fix: reject invalid storage.db_path early across all commands

### DIFF
--- a/crates/tuitbot-cli/src/commands/backup.rs
+++ b/crates/tuitbot-cli/src/commands/backup.rs
@@ -17,7 +17,7 @@ pub async fn execute(args: BackupArgs, config_path: &str, out: CliOutput) -> any
         );
     }
 
-    let db_path = resolve_db_path(config_path);
+    let db_path = resolve_db_path(config_path)?;
     let data = db_path
         .parent()
         .map(|p| p.to_path_buf())

--- a/crates/tuitbot-cli/src/commands/restore.rs
+++ b/crates/tuitbot-cli/src/commands/restore.rs
@@ -57,7 +57,7 @@ pub async fn execute(args: RestoreArgs, config_path: &str, out: CliOutput) -> an
     }
 
     // Confirm unless --force.
-    let target = resolve_db_path(config_path);
+    let target = resolve_db_path(config_path)?;
     if !args.force && std::io::stdin().is_terminal() {
         eprintln!("\nThis will replace the database at {}", target.display());
         eprintln!("A safety backup of the current database will be created first.");

--- a/crates/tuitbot-cli/src/main.rs
+++ b/crates/tuitbot-cli/src/main.rs
@@ -228,6 +228,11 @@ async fn run() -> anyhow::Result<()> {
         }
     };
 
+    // Validate db_path early for all commands except Test (which shows its own diagnostics).
+    if !matches!(&cli.command, Commands::Test(_)) {
+        tuitbot_core::startup::validate_db_path(&config.storage.db_path)?;
+    }
+
     // Check for config upgrade opportunity before `run`
     if matches!(&cli.command, Commands::Run(_)) && std::io::stdin().is_terminal() {
         commands::update::check_before_run(&cli.config).await?;

--- a/crates/tuitbot-core/src/startup.rs
+++ b/crates/tuitbot-core/src/startup.rs
@@ -532,13 +532,37 @@ pub fn expand_tilde(path: &str) -> PathBuf {
 /// Resolve the database path by loading the config file and reading `storage.db_path`.
 ///
 /// Falls back to `~/.tuitbot/tuitbot.db` if the config cannot be loaded.
-pub fn resolve_db_path(config_path: &str) -> PathBuf {
+/// Returns an error if the resolved `db_path` is empty, whitespace-only,
+/// or points to an existing directory.
+pub fn resolve_db_path(config_path: &str) -> Result<PathBuf, crate::error::ConfigError> {
     use crate::config::Config;
-    if let Ok(config) = Config::load(Some(config_path)) {
-        expand_tilde(&config.storage.db_path)
-    } else {
-        data_dir().join("tuitbot.db")
+    let config = match Config::load(Some(config_path)) {
+        Ok(c) => c,
+        Err(_) => return Ok(data_dir().join("tuitbot.db")),
+    };
+
+    validate_db_path(&config.storage.db_path)
+}
+
+/// Validate and expand a `storage.db_path` value.
+///
+/// Rejects empty, whitespace-only, and directory paths with a clear error.
+pub fn validate_db_path(raw: &str) -> Result<PathBuf, crate::error::ConfigError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(crate::error::ConfigError::InvalidValue {
+            field: "storage.db_path".to_string(),
+            message: "must not be empty or whitespace-only".to_string(),
+        });
     }
+    let expanded = expand_tilde(trimmed);
+    if expanded.is_dir() {
+        return Err(crate::error::ConfigError::InvalidValue {
+            field: "storage.db_path".to_string(),
+            message: format!("'{}' is a directory, must point to a file", trimmed),
+        });
+    }
+    Ok(expanded)
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- **All commands now validate `storage.db_path` at startup**, not just `tuitbot test`
- Empty, whitespace-only, and directory paths are rejected with a clear one-line error before any DB operation
- `tuitbot test` is excluded from the gate so it can still show full diagnostic output

Closes #93, closes #94, closes #95

## Root cause

The previous fix (#110) added validation to `check_database()` and `init_db()`, but:
1. Commands like `stats`, `approve`, `run` loaded config via `Config::load()` without validation, hitting confusing `StorageError` wrappers downstream
2. `backup` is dispatched before config load and called `resolve_db_path()` which returned garbage paths silently (e.g., `PathBuf::from("")` → "Database not found at .")
3. `resolve_db_path()` didn't trim or validate the db_path value

## Changes

| File | What |
|------|------|
| `startup.rs` | `resolve_db_path()` → returns `Result` with validation; new `validate_db_path()` shared helper |
| `main.rs` | Validation gate after config load for all commands except `Test` |
| `backup.rs` | Propagates `resolve_db_path()` error via `?` |
| `restore.rs` | Propagates `resolve_db_path()` error via `?` |

## Before / After

**`tuitbot stats` with `db_path = ""`:**
```
- Error: database connection error: storage.db_path must not be empty or whitespace-only
+ Error: invalid value for config field 'storage.db_path': must not be empty or whitespace-only
```

**`tuitbot backup` with `db_path = ""`:**
```
- Error: Database not found at . Run `tuitbot init` first.
+ Error: invalid value for config field 'storage.db_path': must not be empty or whitespace-only
```

**`tuitbot backup` with `db_path = "/tmp"`:**
```
- Error: database connection error: ... unable to open database file ...
+ Error: invalid value for config field 'storage.db_path': '/tmp' is a directory, must point to a file
```

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace` — 2,111 tests pass, 0 failures
- [ ] Manual: `tuitbot stats/approve/backup` with `db_path = ""`, `"   "`, `"/tmp"` → clean validation error
- [ ] Manual: `tuitbot test` with same → still shows full diagnostic output (not blocked by gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)