### PR TITLE
fix: restore release-plz version baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.31](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.30...tuitbot-cli-v0.1.31) - 2026-03-10
-
-### Fixed
-
-- `backup` and `restore` now reject empty, whitespace-only, and directory `storage.db_path` values with a clear config validation error instead of producing misleading downstream errors like "Database not found at ." (#93, #94, #95)
-
 ## [0.1.29](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.28...tuitbot-cli-v0.1.29) - 2026-03-09
 
 ### Added
@@ -441,4 +435,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - modularize the settings command by splitting its logic into dedicated sub-modules.
 - Remove extensive project scaffolding, update core automation loops and CLI commands, and introduce a new scheduling module.
 - Renaming to tuitbot
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,7 +4105,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.31"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.29"
+version = "0.1.28"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.30"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.29"
+version = "0.1.27"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.31"
+version = "0.1.29"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -15,8 +15,8 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.29", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.30", path = "../tuitbot-mcp" }
+tuitbot-core = { version = "0.1.28", path = "../tuitbot-core" }
+tuitbot-mcp = { version = "0.1.29", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.29"
+version = "0.1.28"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.30"
+version = "0.1.29"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.29", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.28", path = "../tuitbot-core" }
 rmcp = { version = "0.16", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,4 +23,4 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.29", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.28", path = "../tuitbot-core", features = ["test-helpers"] }

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.29"
+version = "0.1.27"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"
@@ -12,7 +12,7 @@ keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 include = ["src/**/*", "build.rs", "Cargo.toml", "dashboard-dist/**/*"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.29", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.28", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -34,7 +34,7 @@ rust-embed = { version = "8", features = ["mime-guess"] }
 mime_guess = "2"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.29", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.28", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION
## Summary
Restore the package versions and changelog on `main` to the last published/tagged baseline so `release-plz` can open a normal release PR again.

## Why
A direct `chore: release` commit landed on `main` outside the normal `release-plz-*` PR flow. That left `main` already version-bumped, so later `release-plz release-pr` runs returned `{"prs":[]}` instead of opening a release PR.

This PR reverts only the release metadata drift:
- `CHANGELOG.md`
- package versions in `Cargo.toml`
- internal dependency version pins
- `Cargo.lock`

It intentionally does not touch the unrelated comment-only change in `crates/tuitbot-cli/src/commands/restore.rs`.

## Verification
- `cargo test --workspace`
