### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.29...tuitbot-cli-v0.1.30) - 2026-03-10
+
+### Fixed
+
+- restore release-plz version baseline
+
+### Other
+
+- release
+
 ## [0.1.29](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.28...tuitbot-cli-v0.1.29) - 2026-03-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,7 +4105,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-cli`: 0.1.29 -> 0.1.30
* `tuitbot-server`: 0.1.27 -> 0.1.28

<details><summary><i><b>Changelog</b></i></summary><p>

## `tuitbot-cli`

<blockquote>

## [0.1.30](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.29...tuitbot-cli-v0.1.30) - 2026-03-10

### Fixed

- restore release-plz version baseline

### Other

- release
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).