### PR TITLE
fix(ci): add id-token permission for autofix workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -16,6 +16,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Adds missing `id-token: write` permission to the autofix workflow
- Required by Claude Code Action for OIDC authentication

## Test plan
- [ ] Add `autofix` label to an issue and verify the workflow no longer fails with OIDC error

🤖 Generated with [Claude Code](https://claude.com/claude-code)