### PR TITLE
fix(ci): use explicit github_token in autofix workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           label_trigger: "autofix"
           trigger_phrase: "@claude"
 


### PR DESCRIPTION
## Summary
- Passes `github_token: ${{ secrets.GITHUB_TOKEN }}` explicitly to Claude Code Action
- This skips the OIDC token exchange that requires the Claude GitHub App installed
- Fixes the `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL` error

## Test plan
- [ ] Add `autofix` label to an issue and verify the OIDC error is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)