### PR TITLE
fix(ci): use OAuth token for autofix workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           label_trigger: "autofix"
           trigger_phrase: "@claude"


### PR DESCRIPTION
## Summary
- Switches from `anthropic_api_key` to `claude_code_oauth_token` to match the stored secret type

🤖 Generated with [Claude Code](https://claude.com/claude-code)