### PR TITLE
ci: enable debug output for autofix workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -54,5 +54,7 @@ jobs:
             6. Create a commit with a clear message referencing the issue (e.g., "fix: ... (closes #N)").
             7. Open a PR that links to the issue.
 
+          show_full_output: true
+
           claude_args: |
             --max-turns 30


### PR DESCRIPTION
## Summary
- Adds `show_full_output: true` to see what Claude is doing and why no PR is being created
- Temporary debugging change

🤖 Generated with [Claude Code](https://claude.com/claude-code)