### PR TITLE
fix(ci): allow all tools in autofix workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -58,3 +58,4 @@ jobs:
 
           claude_args: |
             --max-turns 30
+            --allowedTools Edit,Write,Bash,Read,Glob,Grep


### PR DESCRIPTION
## Summary
- Adds `--allowedTools` to pre-approve Edit, Write, Bash, Read, Glob, Grep
- Claude was hitting permission denials because there's no human to approve tool use in CI

## Test plan
- [ ] Re-trigger `autofix` label on an issue and verify Claude can edit files and create a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)