### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.31](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.30...tuitbot-cli-v0.1.31) - 2026-03-10
+
+### Fixed
+
+- *(mcp)* bump tuitbot-mcp to 0.1.30 so manifest ships correct version (closes #123)
+
 ## [0.1.30](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.29...tuitbot-cli-v0.1.30) - 2026-03-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,7 +4105,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-mcp`: 0.1.29 -> 0.1.30
* `tuitbot-cli`: 0.1.30 -> 0.1.31

<details><summary><i><b>Changelog</b></i></summary><p>


## `tuitbot-cli`

<blockquote>

## [0.1.31](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.30...tuitbot-cli-v0.1.31) - 2026-03-10

### Fixed

- *(mcp)* bump tuitbot-mcp to 0.1.30 so manifest ships correct version (closes #123)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).