### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.33](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.32...tuitbot-cli-v0.1.33) - 2026-03-10
+
+### Fixed
+
+- complete audit rows on x_not_configured and reject approval without X auth
+
 ## [0.1.32](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.31...tuitbot-cli-v0.1.32) - 2026-03-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,7 +4105,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuitbot-cli"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-mcp"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-server"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-cli"
-version = "0.1.32"
+version = "0.1.33"
 edition = "2021"
 rust-version = "1.75"
 description = "CLI for Tuitbot autonomous X growth assistant"
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 tuitbot-core = { version = "0.1.29", path = "../tuitbot-core" }
-tuitbot-mcp = { version = "0.1.31", path = "../tuitbot-mcp" }
+tuitbot-mcp = { version = "0.1.32", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = "0.4"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-mcp"
-version = "0.1.31"
+version = "0.1.32"
 edition = "2021"
 rust-version = "1.75"
 description = "MCP server for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-server"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2021"
 rust-version = "1.75"
 description = "HTTP API server for Tuitbot autonomous X growth assistant"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-mcp`: 0.1.31 -> 0.1.32
* `tuitbot-cli`: 0.1.32 -> 0.1.33
* `tuitbot-server`: 0.1.29 -> 0.1.30

<details><summary><i><b>Changelog</b></i></summary><p>


## `tuitbot-cli`

<blockquote>

## [0.1.33](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.32...tuitbot-cli-v0.1.33) - 2026-03-10

### Fixed

- complete audit rows on x_not_configured and reject approval without X auth
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).