### PR TITLE
Extend LAN session cookie lifetime to 30 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Run the server on any always-on machine and access the dashboard from your phone
 cargo run -p tuitbot-server -- --host 0.0.0.0
 ```
 
-The server prints a 4-word passphrase to the terminal on first start. Open `http://<server-ip>:3001` from any device on your network and enter the passphrase to log in. Sessions last 7 days. Full setup guide: [LAN Mode](https://aramirez087.github.io/TuitBot/lan-mode/).
+The server prints a 4-word passphrase to the terminal on first start. Open `http://<server-ip>:3001` from any device on your network and enter the passphrase to log in. Sessions last 30 days. Full setup guide: [LAN Mode](https://aramirez087.github.io/TuitBot/lan-mode/).
 
 ### 3. Self-Hosted Docker
 

--- a/crates/tuitbot-core/src/auth/session.rs
+++ b/crates/tuitbot-core/src/auth/session.rs
@@ -11,8 +11,8 @@ use sha2::{Digest, Sha256};
 use super::error::AuthError;
 use crate::storage::DbPool;
 
-/// Session lifetime: 7 days.
-const SESSION_LIFETIME_DAYS: i64 = 7;
+/// Session lifetime: 30 days.
+pub const SESSION_LIFETIME_DAYS: i64 = 30;
 
 /// A session record as stored in the database.
 #[derive(Debug)]

--- a/crates/tuitbot-server/src/auth/routes.rs
+++ b/crates/tuitbot-server/src/auth/routes.rs
@@ -168,8 +168,9 @@ pub async fn login(
     match session::create_session(&state.db).await {
         Ok(new_session) => {
             let cookie = format!(
-                "tuitbot_session={}; HttpOnly; SameSite=Strict; Path=/; Max-Age=604800",
+                "tuitbot_session={}; HttpOnly; SameSite=Strict; Path=/; Max-Age={}",
                 new_session.raw_token,
+                session::SESSION_LIFETIME_DAYS * 24 * 60 * 60,
             );
 
             let response = LoginResponse {

--- a/crates/tuitbot-server/src/routes/settings/handlers.rs
+++ b/crates/tuitbot-server/src/routes/settings/handlers.rs
@@ -237,8 +237,9 @@ pub async fn init_settings(
             .map_err(|e| ApiError::Internal(format!("failed to create session: {e}")))?;
 
         let cookie = format!(
-            "tuitbot_session={}; HttpOnly; SameSite=Strict; Path=/; Max-Age=604800",
+            "tuitbot_session={}; HttpOnly; SameSite=Strict; Path=/; Max-Age={}",
             new_session.raw_token,
+            session::SESSION_LIFETIME_DAYS * 24 * 60 * 60,
         );
 
         tracing::info!("instance claimed via /settings/init");

--- a/docs/lan-mode.md
+++ b/docs/lan-mode.md
@@ -45,9 +45,9 @@ Tuitbot has two authentication strategies that coexist:
 | Mode | Who uses it | How it works |
 |------|------------|--------------|
 | **Bearer token** | Tauri desktop app, dev mode, API/MCP clients | Reads `~/.tuitbot/api_token` file, sends as `Authorization: Bearer` header |
-| **Session cookie** | Web browsers over LAN | Enter passphrase once, server sets an `HttpOnly` cookie valid for 7 days |
+| **Session cookie** | Web browsers over LAN | Enter passphrase once, server sets an `HttpOnly` cookie valid for 30 days |
 
-When you open the dashboard in a browser without a bearer token on a fresh install, you're directed to the onboarding wizard. At the end of setup, you'll create a passphrase that protects future browser sessions. A session cookie is set automatically, so you're logged in immediately after onboarding. On subsequent visits, if your session has expired, you'll see a login screen where you enter the same passphrase. Sessions last 7 days.
+When you open the dashboard in a browser without a bearer token on a fresh install, you're directed to the onboarding wizard. At the end of setup, you'll create a passphrase that protects future browser sessions. A session cookie is set automatically, so you're logged in immediately after onboarding. On subsequent visits, if your session has expired, you'll see a login screen where you enter the same passphrase. Sessions last 30 days.
 
 ## CLI Flags
 
@@ -187,7 +187,7 @@ Drive connector flow instead of a local file picker.
 - Or from Settings → LAN Access → Reset Passphrase (requires an active session)
 
 **Session expired / redirected to login**
-- Sessions last 7 days. Log in again with the same passphrase
+- Sessions last 30 days. Log in again with the same passphrase
 - If the server was restarted, existing sessions remain valid (they're stored in the database)
 
 **WebSocket not connecting in browser**


### PR DESCRIPTION
## Summary
- extend the LAN/browser session lifetime from 7 days to 30 days
- derive cookie `Max-Age` from the shared session lifetime constant in the auth module
- update README and LAN mode docs to match the new behavior

## Testing
- cargo check -p tuitbot-core
- cargo test -p tuitbot-server auth -- --nocapture