### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "tuitbot-core"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/crates/tuitbot-cli/Cargo.toml
+++ b/crates/tuitbot-cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "tuitbot"
 path = "src/main.rs"
 
 [dependencies]
-tuitbot-core = { version = "0.1.47", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.48", path = "../tuitbot-core" }
 tuitbot-mcp = { version = "0.1.51", path = "../tuitbot-mcp" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"

--- a/crates/tuitbot-core/Cargo.toml
+++ b/crates/tuitbot-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuitbot-core"
-version = "0.1.47"
+version = "0.1.48"
 edition = "2021"
 rust-version = "1.75"
 description = "Core library for Tuitbot autonomous X growth assistant"

--- a/crates/tuitbot-mcp/Cargo.toml
+++ b/crates/tuitbot-mcp/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tuitbot-mcp"
 keywords = ["mcp", "x-api", "twitter", "automation", "agent"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.47", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.48", path = "../tuitbot-core" }
 rmcp = { version = "0.17", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,7 +23,7 @@ anyhow = "1"
 async-trait = "0.1"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.47", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.48", path = "../tuitbot-core", features = ["test-helpers"] }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/tuitbot-server/Cargo.toml
+++ b/crates/tuitbot-server/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["x-api", "twitter", "api-server", "automation", "dashboard"]
 include = ["src/**/*", "build.rs", "Cargo.toml", "dashboard-dist/**/*", "dashboard-release-marker.txt"]
 
 [dependencies]
-tuitbot-core = { version = "0.1.47", path = "../tuitbot-core" }
+tuitbot-core = { version = "0.1.48", path = "../tuitbot-core" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
@@ -34,7 +34,7 @@ rust-embed = { version = "8", features = ["mime-guess"] }
 mime_guess = "2"
 
 [dev-dependencies]
-tuitbot-core = { version = "0.1.47", path = "../tuitbot-core", features = ["test-helpers"] }
+tuitbot-core = { version = "0.1.48", path = "../tuitbot-core", features = ["test-helpers"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tempfile = "3"


### PR DESCRIPTION



## 🤖 New release

* `tuitbot-core`: 0.1.47 -> 0.1.48
* `tuitbot-mcp`: 0.1.50 -> 0.1.51
* `tuitbot-cli`: 0.1.52 -> 0.1.53
* `tuitbot-server`: 0.1.49 -> 0.1.50

<details><summary><i><b>Changelog</b></i></summary><p>



## `tuitbot-cli`

<blockquote>

## [0.1.53](https://github.com/aramirez087/TuitBot/compare/tuitbot-cli-v0.1.52...tuitbot-cli-v0.1.53) - 2026-03-25

### Other

- *(mcp)* split requests.rs into requests/ module directory ([#319](https://github.com/aramirez087/TuitBot/pull/319))
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).